### PR TITLE
Add dependency setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # cole_press
 
 This is a website published with Quarto and Netlify. It can be found [here](https://cole.press).
+
+## Setup
+
+Run `./setup.sh` to install R and Quarto before building the site:
+
+```bash
+./setup.sh
+```

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install R
+sudo apt-get update
+sudo apt-get install -y r-base
+
+# Install Quarto
+QUARTO_VERSION="1.7.31"
+DEB="quarto-${QUARTO_VERSION}-linux-amd64.deb"
+wget -q "https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}/${DEB}"
+sudo dpkg -i "$DEB"
+rm "$DEB"


### PR DESCRIPTION
## Summary
- add `setup.sh` to install R and Quarto
- document setup script usage in README

## Testing
- `bash -n setup.sh`


------
https://chatgpt.com/codex/tasks/task_e_68413cf6159c832097bfd3e7b0862b59