### PR TITLE
Stop ignoring built site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 
 /.quarto/
 
-/_site/
 /_freeze/
 /about_cache/
 /index_cache/


### PR DESCRIPTION
## Summary
- stop ignoring `_site` so the built Quarto output can be committed

## Testing
- `quarto render` *(fails: Theme file compilation failed)*

------
https://chatgpt.com/codex/tasks/task_e_6841440cec288320886d8956186253a9